### PR TITLE
remove while loop, prevent cpu blocking using monotonically increase instead.

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,12 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 var hostname = require('os').hostname().substr(0, 3);
 var MachineProcessId = process.pid.toString(36) + (hostname.charCodeAt(0) + hostname.charCodeAt(1) + hostname.charCodeAt(2)).toString(36) ;
 module.exports = function(prefix){
+	return (prefix || '') + MachineProcessId + now().toString(36);
+}
+
+function now(){
 	var time = new Date().getTime();
-	while (time == new Date().getTime());
-	return (prefix || '') + MachineProcessId + new Date().getTime().toString(36);
+  var last = now.last || time;
+  now.last = time > last ? time : last + 1;
+  return now.last;
 }


### PR DESCRIPTION
The while loop blocks cpu cycles which is most noticeable when used in a loop!
Testing
```javascript
var uniqid = require('./')
for (var i = 0; i < 10000; i++) console.log(uniqid())
```
I get 

```
node test  9.12s user 0.59s system 95% cpu 10.179 total
```

With the while replaced with a monotonic increment (this PR) I get

```
node test  0.12s user 0.10s system 112% cpu 0.200 total
```