### PR TITLE
fix: missing variable declaration

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ var pid = process && process.pid ? process.pid.toString(36) : '' ;
 var address = '';
 if(typeof __webpack_require__ !== 'function'){
     var mac = '', networkInterfaces = require('os').networkInterfaces();
-    for(interface_key in networkInterfaces){
+    for(let interface_key in networkInterfaces){
         const networkInterface = networkInterfaces[interface_key];
         const length = networkInterface.length;
         for(var i = 0; i < length; i++){


### PR DESCRIPTION
This fixes a missing variable declaration which makes Jest fail. Should be catched by a linter actually.