### PR TITLE
Use ternary operators for default parameters

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,9 +29,9 @@ if(typeof __webpack_require__ !== 'function'){
 
 //  Exports
 // ================================================
-module.exports = module.exports.default = function(prefix = '', suffix = ''){ return prefix + address + pid + now().toString(36) + suffix; }
-module.exports.process = function(prefix = '', suffix = ''){ return prefix + pid + now().toString(36) + suffix; }
-module.exports.time    = function(prefix = '', suffix = ''){ return prefix + now().toString(36) + suffix; }
+module.exports = module.exports.default = function(prefix, suffix){ return (prefix ? prefix : '') + address + pid + now().toString(36) + (suffix ? suffix : ''); }
+module.exports.process = function(prefix, suffix){ return (prefix ? prefix : '') + pid + now().toString(36) + (suffix ? suffix : ''); }
+module.exports.time    = function(prefix, suffix){ return (prefix ? prefix : '') + now().toString(36) + (suffix ? suffix : ''); }
 
 //  Helpers
 // ================================================


### PR DESCRIPTION
Fixes an issue with using uniqid in a browser-side application on IE11.

Closes issue: https://github.com/adamhalasz/uniqid/issues/32